### PR TITLE
enable callback in Subscriber to support function dynamic binding

### DIFF
--- a/include/tzc_transport/tzc_publisher.hpp
+++ b/include/tzc_transport/tzc_publisher.hpp
@@ -52,6 +52,13 @@ public:
     if (ptr) {
       msg.fillArray(pobj_->convertAddress2Handle(ptr), ptr);
       msg.magic_ = ptr->magic_ = rand();
+
+      //link the head of shm
+      msg.pmsg_ = pobj_ -> pmsg_;
+      msg.pmsg_ -> take();
+      msg.name_ = pobj_ -> getName();
+      msg.pshm_ = pobj_ -> pshm_;
+
       pobj_->addLast(ptr);
     }
     return (ptr != NULL);

--- a/include/tzc_transport/tzc_subscriber.hpp
+++ b/include/tzc_transport/tzc_subscriber.hpp
@@ -14,7 +14,7 @@ class Subscriber;
 template < class M >
 class SubscriberCallbackHelper
 {
-  typedef void (*Func)(const typename M::ConstPtr &);
+  typedef const boost::function<void (const typename M::ConstPtr &)> Func;
 
 public:
   ~SubscriberCallbackHelper() {

--- a/include/tzc_transport/tzc_topic.hpp
+++ b/include/tzc_transport/tzc_topic.hpp
@@ -31,6 +31,13 @@ public:
     return Subscriber< M >(sub, phlp);
   }
 
+  template < class M, class T >
+  Subscriber< M > subscribe(const std::string & topic, uint32_t queue_size, void (T::*fp)(const boost::shared_ptr< const M > &), T* obj) {
+    SubscriberCallbackHelper< M > * phlp = new SubscriberCallbackHelper< M >(topic, boost::bind(fp, obj, _1));
+    ros::Subscriber sub = nh_.subscribe(topic, queue_size, &SubscriberCallbackHelper< M >::callback, phlp, ros::TransportHints().tcpNoDelay());
+    return Subscriber< M >(sub, phlp);
+  }
+
 private:
   ros::NodeHandle nh_;
 


### PR DESCRIPTION
1:topic初始化subscriber时，可传递一个对象的成员函数
2:baseMsg增加shmManager和shmMessage的头指针。当Msg被allocate时，头指针take,并且Manager被共享;当Msg被析构时，判断是最后一个头指针引用，则释放共享文件。